### PR TITLE
fix: pin upstream firmware to git commit

### DIFF
--- a/pkgs/firmware/light_aon_fpga.nix
+++ b/pkgs/firmware/light_aon_fpga.nix
@@ -4,10 +4,10 @@
 }:
 stdenv.mkDerivation {
   pname = "light_aon_fpga-firmware";
-  version = "unstable-2023-06-25";
+  version = "unstable-2023-08-04";
 
   src = fetchurl {
-    url = "https://github.com/chainsx/fedora-riscv-builder/raw/20230623-0255/firmware/light_aon_fpga.bin";
+    url = "https://github.com/chainsx/fedora-riscv-builder/raw/f35095c9f45b42addb1b0d0e9185ca8ff04ed870/firmware/light_aon_fpga.bin"; # tag: 20230804-1242
     hash = "sha256-cIFaWDbiX0nNzlhkhhKapjGeN64dblFE1DxZh01kV5s=";
   };
 

--- a/pkgs/firmware/light_c906_audio.nix
+++ b/pkgs/firmware/light_c906_audio.nix
@@ -4,10 +4,10 @@
 }:
 stdenv.mkDerivation {
   pname = "light_c906_audio-firmware";
-  version = "unstable-2023-06-25";
+  version = "unstable-2023-08-04";
 
   src = fetchurl {
-    url = "https://github.com/chainsx/fedora-riscv-builder/raw/20230623-0255/firmware/light_c906_audio.bin";
+    url = "https://github.com/chainsx/fedora-riscv-builder/raw/f35095c9f45b42addb1b0d0e9185ca8ff04ed870/firmware/light_c906_audio.bin"; # tag: 20230804-1242
     hash = "sha256-hv9OQhc6cH7swqVrhPhIxgUsgH4JMiOjw+DRWcK9nNQ=";
   };
 


### PR DESCRIPTION
The previous tag has been deleted? The files didn't change, though: the hashes still match.